### PR TITLE
In etc/xm.tmpl, added /usr/local/bin/pygrub to pygrub search path.

### DIFF
--- a/etc/xm.tmpl
+++ b/etc/xm.tmpl
@@ -23,7 +23,8 @@
     my $pygrub_bin = '';
     foreach my $pygrub_path (reverse glob('/usr/lib/xen-default/bin/pygrub
                                            /usr/lib/xen-*/bin/pygrub
-                                           /usr/*bin/pygrub')) {
+                                           /usr/*bin/pygrub
+                                           /usr/local/bin/pygrub')) {
       if (-x $pygrub_path) {
         $pygrub_bin = $pygrub_path;
         last;


### PR DESCRIPTION
Hello,

I use Xen 4.7 on Ubuntu 14.04 amd64. With this configuration the path for pygrub is /usr/local/pygrub, so I added it to pygrub search path im etc/xm.tmpl.