### PR TITLE
Eliminate progress reporting which is useless in logs

### DIFF
--- a/hooks/common.sh
+++ b/hooks/common.sh
@@ -96,7 +96,7 @@ installDebianPackageAndRecommends ()
     #
     # Install the packages
     #
-    DEBIAN_FRONTEND=noninteractive chroot ${prefix} /usr/bin/apt-get --yes install "$@"
+    DEBIAN_FRONTEND=noninteractive chroot ${prefix} /usr/bin/apt-get --quiet --yes install "$@" | sed --expression="/^\rExtracting templates from packages: /d;s/(Reading database ... \([0-9]\+%\)\?\r//g"
 
     #
     #  Remove the policy-rc.d script.

--- a/hooks/common.sh
+++ b/hooks/common.sh
@@ -96,7 +96,7 @@ installDebianPackageAndRecommends ()
     #
     # Install the packages
     #
-    DEBIAN_FRONTEND=noninteractive chroot ${prefix} /usr/bin/apt-get --quiet --yes install "$@" | sed --expression="/^\rExtracting templates from packages: /d;s/(Reading database ... \([0-9]\+%\)\?\r//g"
+    DEBIAN_FRONTEND=noninteractive chroot ${prefix} /usr/bin/apt-get --quiet --yes install "$@" 2>&1 | sed --expression="s/\rExtracting templates from packages: [0-9]\+%//g;s/(Reading database ... \([0-9]\+%\)\?\r//g"
 
     #
     #  Remove the policy-rc.d script.


### PR DESCRIPTION
Hello,

I've made this little change that sanitizes logs a little by filtering out information about progress during software/packages install. Without it logs are full of (Reading database ... 5%^M(Reading database ... 10%^M and so on stuff.

Yuri Sakhno.
