### PR TITLE
Changed 'on_crash' value to 'destroy' as specified in xl.cfg manpage.

### DIFF
--- a/etc/xm.tmpl
+++ b/etc/xm.tmpl
@@ -171,7 +171,7 @@ name        = '{$hostname}'
 #
 on_poweroff = 'destroy'
 on_reboot   = 'restart'
-on_crash    = 'restart'
+on_crash    = 'destroy'
 
 
 { if ( $admins )


### PR DESCRIPTION
This would fix https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=853083