### PR TITLE
Fix storage commandline options not overriding xen-tools.conf settings

### DIFF
--- a/bin/xen-delete-image
+++ b/bin/xen-delete-image
@@ -269,13 +269,25 @@ sub parseCommandLineArguments
     my $VERSION = 0;
     $CONFIG{ 'dry-run' } = 0;
 
+    #
+    #  We record the installation method here because we want
+    # to ensure that we allow the method supplied upon the command line
+    # to overwrite the one we might have ready read from the configuration
+    # file.
+    #
+    my %install;
+    $install{ 'evms' }      = undef;
+    $install{ 'dir' }       = undef;
+    $install{ 'lvm' }       = undef;
+    $install{ 'zpool' }     = undef;
+
     #  Parse options.
     #
-    GetOptions( "dir=s",       \$CONFIG{ 'dir' },
+    GetOptions( "dir=s",       \$install{ 'dir' },
                 "dry-run",     \$CONFIG{ 'dry-run' },
-                "lvm=s",       \$CONFIG{ 'lvm' },
-                "evms=s",      \$CONFIG{ 'evms' },
-                "zpool=s",     \$CONFIG{ 'zpool' },
+                "lvm=s",       \$install{ 'lvm' },
+                "evms=s",      \$install{ 'evms' },
+                "zpool=s",     \$install{ 'zpool' },
                 "extension:s", \$CONFIG{ 'extension' },
                 "hostname=s@", \$CONFIG{ 'hostname' },
                 "test",        \$CONFIG{ 'test' },
@@ -285,6 +297,39 @@ sub parseCommandLineArguments
                 "manual",      \$MANUAL,
                 "version",     \$VERSION
               );
+
+    #
+    #  Now make ensure that the command line setting of '--lvm', '--evms', '--zpool'
+    # and '--dir=x' override anything specified in the configuration file.
+    #
+    if ( $install{ 'dir' } )
+    {
+        $CONFIG{ 'dir' }       = $install{ 'dir' };
+        $CONFIG{ 'evms' }      = undef;
+        $CONFIG{ 'lvm' }       = undef;
+        $CONFIG{ 'zpool' }     = undef;
+    }
+    if ( $install{ 'evms' } )
+    {
+        $CONFIG{ 'dir' }       = undef;
+        $CONFIG{ 'evms' }      = $install{ 'evms' };
+        $CONFIG{ 'lvm' }       = undef;
+        $CONFIG{ 'zpool' }     = undef;
+    }
+    if ( $install{ 'lvm' } )
+    {
+        $CONFIG{ 'dir' }       = undef;
+        $CONFIG{ 'evms' }      = undef;
+        $CONFIG{ 'lvm' }       = $install{ 'lvm' };
+        $CONFIG{ 'zpool' }     = undef;
+    }
+    if ( $install{ 'zpool' } )
+    {
+        $CONFIG{ 'dir' }       = undef;
+        $CONFIG{ 'evms' }      = undef;
+        $CONFIG{ 'lvm' }       = undef;
+        $CONFIG{ 'zpool' }     = $install{ 'zpool' };
+    }
 
     pod2usage(1) if $HELP;
     pod2usage( -verbose => 2 ) if $MANUAL;

--- a/bin/xen-update-image
+++ b/bin/xen-update-image
@@ -344,14 +344,51 @@ sub parseCommandLineArguments
     my $MANUAL  = 0;
     my $VERSION = 0;
 
+    #
+    # We record the installation method here because we want
+    # to ensure that we allow the method supplied upon the command line
+    # to overwrite the one we might have ready read from the configuration
+    # file.
+    #
+    my %install;
+    $install{ 'evms' }      = undef;
+    $install{ 'dir' }       = undef;
+    $install{ 'lvm' }       = undef;
+
     #  Parse options.
     #
-    GetOptions( "dir=s",  \$CONFIG{ 'dir' },
-                "lvm=s",   \$CONFIG{ 'lvm' },
-                "evms=s", \$CONFIG{ 'evms' },
+    GetOptions( "dir=s",  \$install{ 'dir' },
+                "lvm=s",   \$install{ 'lvm' },
+                "evms=s", \$install{ 'evms' },
                 "help",    \$HELP,
                 "manual", \$MANUAL,
                 "version", \$VERSION );
+
+    #
+    #  Now make ensure that the command line setting of '--lvm', '--evms', '--zpool'
+    # and '--dir=x' override anything specified in the configuration file.
+    #
+    if ( $install{ 'dir' } )
+    {
+        $CONFIG{ 'dir' }       = $install{ 'dir' };
+        $CONFIG{ 'evms' }      = undef;
+        $CONFIG{ 'lvm' }       = undef;
+        $CONFIG{ 'zpool' }     = undef;
+    }
+    if ( $install{ 'evms' } )
+    {
+        $CONFIG{ 'dir' }       = undef;
+        $CONFIG{ 'evms' }      = $install{ 'evms' };
+        $CONFIG{ 'lvm' }       = undef;
+        $CONFIG{ 'zpool' }     = undef;
+    }
+    if ( $install{ 'lvm' } )
+    {
+        $CONFIG{ 'dir' }       = undef;
+        $CONFIG{ 'evms' }      = undef;
+        $CONFIG{ 'lvm' }       = $install{ 'lvm' };
+        $CONFIG{ 'zpool' }     = undef;
+    }
 
     pod2usage(1) if $HELP;
     pod2usage( -verbose => 2 ) if $MANUAL;


### PR DESCRIPTION
Was already fixed in xen-create-image, but neither in
xen-delete-image nor in xen-update-image. Use the same code as in
xen-create-image in those two tools, too.