### PR TITLE
Add support for specifying guest type

### DIFF
--- a/bin/xen-create-image
+++ b/bin/xen-create-image
@@ -216,7 +216,7 @@ and EVMS EXAMPLE.
                 have instead of the default value of "1".
 
    --type=type  Specify the VM type to use for the new guest.
-                Valid choices are 'pv' (default), 'pvh', or 'pvh'.                 xfs)
+                Valid choices are 'pv' (default), 'pvh', or 'pvh'.
 
 
   Installation options:

--- a/bin/xen-create-image
+++ b/bin/xen-create-image
@@ -215,6 +215,8 @@ and EVMS EXAMPLE.
                 Set the number of vcpus that the new instance will
                 have instead of the default value of "1".
 
+   --type=type  Specify the VM type to use for the new guest.
+                Valid choices are 'pv' (default), 'pvh', or 'pvh'.                 xfs)
 
 
   Installation options:
@@ -1345,6 +1347,7 @@ sub setupDefaultOptions
     $CONFIG{ 'ipfile' }        = '/etc/xen-tools/ips.txt';
     $CONFIG{ 'output' }        = '/etc/xen';
     $CONFIG{ 'extension' }     = '.cfg';
+    $CONFIG{ 'type' }          = 'pv';   # Arno: as per man xl.cfg
 
     #
     #  Installation method defaults to "debootstrap" using
@@ -1490,6 +1493,10 @@ sub checkOption
         vlan => {
             check   => qr/^([1-9][0-9]{0,2}|10[01][0-9]|102[0-4])$/i,
             message => "must be a number between 1 and 1024.\n",
+        }, # Arno
+        guestType => {
+            check   => qr/^pv|pvh|hvm$/,    # man xl.cfg
+            message => "must be 'pv', 'pvh' or 'hvm'.\n",
         },
     );
 
@@ -1529,6 +1536,7 @@ sub checkOption
         hash_method   => 'hashMethod',
         apt_proxy     => 'uri',
         vlan          => 'vlan',
+	type          => 'guestType', # Arno
     );
 
     # If given option does not exists in optionsTypes,
@@ -1685,7 +1693,8 @@ sub parseCommandLineArguments
             "extension:s",  \&checkOption,
             "dontformat",   \&checkOption,
             "lvm_thin=s",   \$CONFIG{ 'lvm_thin' },
-
+            "type:s",       \&checkOption, # Arno
+	    
             # Help options
             "debug!",     \$CONFIG{ 'debug' },
             "help",       \$HELP,
@@ -2719,6 +2728,7 @@ sub showSummary
         }
     }
 
+    logprint("Guest type     :  $CONFIG{'type'}\n");
     logprint("Image type     :  $CONFIG{'image'}\n");
     logprint("Memory size    :  $CONFIG{'memory'}\n");
 

--- a/etc/xm.tmpl
+++ b/etc/xm.tmpl
@@ -30,6 +30,7 @@ memory      = '{$memory}'
     $OUT .= "maxmem      = '$maxmem'\n";
   }
 }
+type      = '{$type}'
 
 #
 #  Disk device(s).


### PR DESCRIPTION
Hi
for us it is useful to be able to specify the VM guest type (PV,PVH,HVM) on the command-line. In particular, to work around a bug in modern kernels where PV guests crash if they have memory less than 4 GiB. Solution is to use PVH guests, which Xen developers actually recommend.

Reference to bug: https://github.com/QubesOS/qubes-issues/issues/6052#issuecomment-882548007

CU,
           Arno